### PR TITLE
Feature/ULF-2394: Ribbon sold out

### DIFF
--- a/src/Pretix/EventHelper.php
+++ b/src/Pretix/EventHelper.php
@@ -613,6 +613,14 @@ class EventHelper extends AbstractHelper {
         // Flush cache for node.
         $cid = url('node/' . $node->nid, ['absolute' => TRUE]);
         cache_clear_all($cid, 'cache_page');
+        // Re-index the node in the 'courses' index.
+        if (module_exists('search_api')) {
+          $index = search_api_index_load('courses');
+          if (NULL !== $index) {
+            search_api_entity_update($node, 'node');
+            search_api_index_items($index);
+          }
+        }
       }
     }
   }

--- a/ulf_pretix.module
+++ b/ulf_pretix.module
@@ -361,3 +361,16 @@ function ulf_pretix_tokens($type, $tokens, array $data = [], array $options = []
 
   return $replacements;
 }
+
+/**
+ * Implements hook_search_node_filtered_item_alter().
+ */
+function ulf_pretix_search_node_filtered_item_alter(&$filteredItem) {
+  if (isset($filteredItem['nid'])) {
+    $node = node_load($filteredItem['nid']);
+    if (isset($node->pretix['data']['available']) && FALSE === $node->pretix['data']['available']) {
+      $filteredItem['ribbon_message'] = t('Sold out');
+      $filteredItem['ribbon_class_names'] = ['warning'];
+    }
+  }
+}


### PR DESCRIPTION
https://jira.itkdev.dk/browse/ULF-2394

To be used in Angular templates:

```
    <article class="search-results--result is-dagtilbud" data-ng-repeat="hit in hits.results">
      <div class="ribbon-wrapper left {{ hit.ribbon_class }}" data-ng-if="hit.ribbon_message">
        <div class="ribbon">
          <a href="{{ hit.url }}">{{ hit.ribbon_message }}</a>
        </div>
      </div>
      <div class="ribbon-wrapper left" data-ng-if="!hit.ribbon_message && hit.field_free == true">
        <div class="ribbon">
          <a href="{{ hit.url }}">Gratis</a>
        </div>
      </div>
      …
```

The “Gratis” stuff is left for backwards compatibility.